### PR TITLE
Update project references from Website-Portfolio to Portfolio

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,7 +28,7 @@ author: Matthew Allen
 author_bio: Hi, my name is Matthew Allen. I am a student at Boston University studying Computer Science!
 author_email: "allenmc220@gmail.com"
 author_location: Boston & Kansas City
-author_website_url: "https://mallen220.github.io/Website-Portfolio/" #TODO: Update this with my website URL
+author_website_url: "https://mallen220.github.io/Portfolio/" #TODO: Update this with my website URL
 typewrite-text: Hello! I'm a student at Boston University studying Computer Science!
 hero_cover_img: home_screen.jpg # replace this for changing homepage cover (eg. try cover.jpeg). Image should be in /assets/img
 

--- a/_includes/blog_post_article.html
+++ b/_includes/blog_post_article.html
@@ -52,7 +52,7 @@
   <div class="comments">
     <script
       src="https://giscus.app/client.js"
-      data-repo="Mallen220/Website-Portfolio"
+      data-repo="Mallen220/Portfolio"
       data-repo-id="R_kgDOPJyHNw"
       data-category="Announcements"
       data-category-id="DIC_kwDOPJyHN84Cs1hr"

--- a/gallery_generator.rb
+++ b/gallery_generator.rb
@@ -17,9 +17,9 @@ require "yaml"
 require "fileutils"
 
 ROOT       = File.expand_path(__dir__ + "/..") # repo root (scripts/..)
-GALLERY    = File.join(ROOT, "Website-Portfolio/assets/img/gallery")
-GALLERY_MD = File.join(ROOT, "Website-Portfolio/gallery") # Markdown files location
-DATA_DIR   = File.join(ROOT, "Website-Portfolio/_data/galleries")
+GALLERY    = File.join(ROOT, "Portfolio/assets/img/gallery")
+GALLERY_MD = File.join(ROOT, "Portfolio/gallery") # Markdown files location
+DATA_DIR   = File.join(ROOT, "Portfolio/_data/galleries")
 VALID_EXTS = %w[jpg jpeg png gif webp]
 
 # Find title from gallery markdown files

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "website-portfolio",
+  "name": "portfolio",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "website-portfolio",
+      "name": "portfolio",
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "website-portfolio",
+  "name": "portfolio",
   "version": "1.0.0",
   "description": "<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section --> [![All Contributors](https://img.shields.io/badge/all_contributors-14-orange.svg?style=flat-square)](#contributors-) <!-- ALL-CONTRIBUTORS-BADGE:END -->",
   "main": "index.js",
@@ -9,16 +9,16 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Mallen220/Website-Portfolio.git"
+    "url": "git+https://github.com/Mallen220/Portfolio.git"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "type": "commonjs",
   "bugs": {
-    "url": "https://github.com/Mallen220/Website-Portfolio/issues"
+    "url": "https://github.com/Mallen220/Portfolio/issues"
   },
-  "homepage": "https://github.com/Mallen220/Website-Portfolio#readme",
+  "homepage": "https://github.com/Mallen220/Portfolio#readme",
   "devDependencies": {
     "husky": "^9.1.7",
     "lint-staged": "^16.1.5",


### PR DESCRIPTION
Renamed all occurrences of 'Website-Portfolio' to 'Portfolio' in configuration files, HTML includes, Ruby scripts, and package metadata to reflect the new project name and repository URL.