### PR TITLE
Adjust scroll buffer for image loading

### DIFF
--- a/_layouts/gallery.html
+++ b/_layouts/gallery.html
@@ -174,7 +174,7 @@ layout: default
     function checkAndLoad() {
       if (isLoading) return;
 
-      const buffer = 1000;
+      const buffer = 750;
       if ($(window).scrollTop() + $(window).height() >= $(document).height() - buffer) {
         loadMoreImages();
       }


### PR DESCRIPTION
Reduced the scroll buffer from 1000 to 750 pixels before triggering the loading of more images in the gallery layout. This change makes additional images load slightly later as the user scrolls.