### PR TITLE
Add dates to gallery overview and sort by date

### DIFF
--- a/_data/galleries/overview.yml
+++ b/_data/galleries/overview.yml
@@ -1,72 +1,90 @@
-- title: Boston Marathon 2025 Gallery
-  directory: BostonMarathon2025
-  preview:
-    filename: BostonMarathon2025-13.jpg
-- title: Boston March For Science Protest 2025
-  directory: MarchForScience2025
-  preview:
-    filename: MarchForScience2025.jpg
-- title: Boston University Photo Adventures
-  directory: BUPhotoAdventures
-  preview:
-    filename: BUPhotoAdventures.jpg
-- title: Brookline Bots Canada Premiere Event 2025 Gallery
-  directory: 17218CanadianPremiere2025
-  preview:
-    filename: CanadaPremiereEvent2025-7103.jpg
-- title: BU Men's Ice Hockey on 1/24
-  directory: MensIceHockey1-24-2025
-  preview:
-    filename: BUHockeyVsBC--10.jpg
-- title: BU Men's Ice Hockey on 1/31
-  directory: MensIceHockey1-31-2025
-  preview:
-    filename: BUHockeyVsUNH--10.jpg
-- title: BU Men's Ice Hockey on 10/12
-  directory: MensIceHockey10-12-2024
-  preview:
-    filename: BU-Hockey-10-12-2024--10.jpg
-- title: BU Women's Hockey vs UConn 2025 Gallery
-  directory: BUICEWVSUCONN
-  preview:
-    filename: BUvsUCONN--10.jpg
-- title: BU Women's Rugby on 10/20/24
-  directory: BUWomensRugby10-20-2024
-  preview:
-    filename: BU-Rugby-10-20-2024--10.jpg
-- title: BU Women's Rugby on 10/6/24
-  directory: BURugby10-6-2024
-  preview:
-    filename: BU-Rugby-10-6-2024--11.jpg
-- title: BU Women's Rugby on 9/29/24
-  directory: BURugby9-29-2024
-  preview:
-    filename: BURugby9-29-2024.jpg
 - title: Europe 2025 Adventure!
   directory: Europe2025
   preview:
     filename: Europe2025.jpg
-- title: New York City Photos
-  directory: NYCPhotos
-  preview:
-    filename: NYC--10.jpg
-- title: Offside Ostriches 06/22.
-  directory: OO2025-6-22
-  preview:
-    filename: OOSoccer2025-4907.jpg
-- title: Offside Ostriches 06/29.
-  directory: OO2025-6-29
-  preview:
-    filename: OOSoccer2025-5332.jpg
-- title: Offside Ostriches 07/13.
-  directory: OO2025-7-13
-  preview:
-    filename: OOSoccer2025-6502.jpg
-- title: Offside Ostriches 7/6.
-  directory: OO2025-7-6
-  preview:
-    filename: OOSoccer2025-5844.jpg
+  date: "2025-08-04"
 - title: Offside Ostriches 8/3.
   directory: OO2025-8-3
   preview:
     filename: OOSoccerAug3-7683.jpg
+  date: "2025-08-03"
+- title: Brookline Bots Canada Premiere Event 2025 Gallery
+  directory: 17218CanadianPremiere2025
+  preview:
+    filename: CanadaPremiereEvent2025-7103.jpg
+  date: "2025-07-25"
+- title: Offside Ostriches 07/13.
+  directory: OO2025-7-13
+  preview:
+    filename: OOSoccer2025-6502.jpg
+  date: "2025-07-13"
+- title: Offside Ostriches 7/6.
+  directory: OO2025-7-6
+  preview:
+    filename: OOSoccer2025-5844.jpg
+  date: "2025-07-06"
+- title: Offside Ostriches 06/29.
+  directory: OO2025-6-29
+  preview:
+    filename: OOSoccer2025-5332.jpg
+  date: "2025-06-29"
+- title: Offside Ostriches 06/22.
+  directory: OO2025-6-22
+  preview:
+    filename: OOSoccer2025-4907.jpg
+  date: "2025-06-22"
+- title: Boston Marathon 2025 Gallery
+  directory: BostonMarathon2025
+  preview:
+    filename: BostonMarathon2025-13.jpg
+  date: "2025-04-21"
+- title: New York City Photos
+  directory: NYCPhotos
+  preview:
+    filename: NYC--10.jpg
+  date: "2025-03-17"
+- title: Boston March For Science Protest 2025
+  directory: MarchForScience2025
+  preview:
+    filename: MarchForScience2025.jpg
+  date: "2025-03-15"
+- title: BU Women's Hockey vs UConn 2025 Gallery
+  directory: BUICEWVSUCONN
+  preview:
+    filename: BUvsUCONN--10.jpg
+  date: "2025-02-22"
+- title: BU Men's Ice Hockey on 1/31
+  directory: MensIceHockey1-31-2025
+  preview:
+    filename: BUHockeyVsUNH--10.jpg
+  date: "2025-01-31"
+- title: BU Men's Ice Hockey on 1/24
+  directory: MensIceHockey1-24-2025
+  preview:
+    filename: BUHockeyVsBC--10.jpg
+  date: "2025-01-24"
+- title: BU Women's Rugby on 10/20/24
+  directory: BUWomensRugby10-20-2024
+  preview:
+    filename: BU-Rugby-10-20-2024--10.jpg
+  date: "2024-10-20"
+- title: BU Men's Ice Hockey on 10/12
+  directory: MensIceHockey10-12-2024
+  preview:
+    filename: BU-Hockey-10-12-2024--10.jpg
+  date: "2024-10-12"
+- title: BU Women's Rugby on 10/6/24
+  directory: BURugby10-6-2024
+  preview:
+    filename: BU-Rugby-10-6-2024--11.jpg
+  date: "2024-10-06"
+- title: Boston University Photo Adventures
+  directory: BUPhotoAdventures
+  preview:
+    filename: BUPhotoAdventures.jpg
+  date: "2024-10-01"
+- title: BU Women's Rugby on 9/29/24
+  directory: BURugby9-29-2024
+  preview:
+    filename: BURugby9-29-2024.jpg
+  date: "2024-09-29"

--- a/gallery/Europe2025.md
+++ b/gallery/Europe2025.md
@@ -3,7 +3,7 @@ layout: gallery
 title: Europe 2025 Adventure!
 description: "Photos from the Netherlands, Germany, and France"
 picture_path: Europe2025
-date: 2025-08-01
+date: 2025-08-04
 #google_photos_album: "https://photos.google.com/share/your-album-link"
 private: false
 ---

--- a/gallery_generator.rb
+++ b/gallery_generator.rb
@@ -5,16 +5,18 @@
 #   - _data/galleries/overview.yml with one entry per folder
 #
 # Behavior:
-#   - Uses gallery markdown files to find titles
+#   - Uses gallery markdown files to find titles and dates
 #   - Sets preview image to first image in folder if custom preview doesn't exist
 #   - Only considers originals (ignores files ending with -thumbnail.*).
 #   - Supports extensions: jpg|jpeg|png|gif|webp (case-insensitive).
 #   - Writes "filename" without extension; "original" uses the same extension as source.
 #   - Ensures overview preview images exist; if missing, uses first picture.
 #   - Removes stale *_data/galleries/*.yml (except overview.yml) that no longer correspond to folder.
+#   - Includes date field from markdown front matter in overview.yml
 
 require "yaml"
 require "fileutils"
+require "date"
 
 ROOT       = File.expand_path(__dir__ + "/..") # repo root (scripts/..)
 GALLERY    = File.join(ROOT, "Portfolio/assets/img/gallery")
@@ -22,20 +24,27 @@ GALLERY_MD = File.join(ROOT, "Portfolio/gallery") # Markdown files location
 DATA_DIR   = File.join(ROOT, "Portfolio/_data/galleries")
 VALID_EXTS = %w[jpg jpeg png gif webp]
 
-# Find title from gallery markdown files
-def find_title_for_folder(folder_name)
-  return folder_name.capitalize unless Dir.exist?(GALLERY_MD)
+# Find title and date from gallery markdown files
+def find_metadata_for_folder(folder_name)
+  metadata = { title: folder_name.capitalize, date: nil }
+  return metadata unless Dir.exist?(GALLERY_MD)
 
   Dir.glob(File.join(GALLERY_MD, "*.md")).each do |file|
     content = File.read(file)
     if content.include?("picture_path: #{folder_name}")
+      # Extract title
       if match = content.match(/title: ["']?(.+?)["']?(\n|$)/)
-        return match[1].strip
+        metadata[:title] = match[1].strip
+      end
+
+      # Extract date
+      if match = content.match(/date: ["']?(\d{4}-\d{2}-\d{2})["']?(\n|$)/)
+        metadata[:date] = match[1].strip
       end
     end
   end
 
-  folder_name.capitalize # Fallback to capitalized folder name
+  metadata
 end
 
 def valid_image?(filename)
@@ -162,22 +171,40 @@ def generate
     yml_path = write_gallery_yaml(folder_name, yaml_pictures)
     generated_files << File.basename(yml_path)
 
-    # Get title from markdown file or use folder name
-    title = find_title_for_folder(folder_name)
+    # Get title and date from markdown file or use folder name
+    metadata = find_metadata_for_folder(folder_name)
+    title = metadata[:title]
+    date = metadata[:date]
 
     # Get preview filename
     preview_filename = get_preview_filename(folder_path, folder_name, pictures)
 
-    overview_entries << {
+    # Create overview entry with date if available
+    overview_entry = {
       "title" => title,
       "directory" => folder_name,
       "preview" => {
         "filename" => preview_filename,
       }
     }
+
+    # Add date to overview entry if available
+    overview_entry["date"] = date if date
+
+    overview_entries << overview_entry
   end
 
-  overview_entries.sort_by! { |e| e["title"].downcase }
+  # Sort overview entries by date (if available) or by title
+  overview_entries.sort_by! do |e|
+    if e["date"]
+      # Parse date for proper sorting (newest first)
+      [Date.parse(e["date"]), e["title"]]
+    else
+      # For entries without date, use a very old date so they appear last
+      [Date.parse("1900-01-01"), e["title"]]
+    end
+  end.reverse!
+
   write_overview_yaml(overview_entries)
   generated_files << "overview.yml"
 
@@ -191,6 +218,7 @@ def generate
      end
 
   puts "Generated YAML for #{folders.size} galleries."
+  puts "Overview entries sorted by date (newest first)."
 end
 
 generate


### PR DESCRIPTION
Updated the gallery overview YAML to include a date field for each gallery, extracted from the markdown front matter. Modified the gallery generator to parse and include dates, and to sort overview entries by date (newest first) instead of title. Also updated the Europe 2025 gallery date.